### PR TITLE
chore: add claude skills, align hooks with CI, fix docs

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: create-pr
+description: Create well-formed pull requests for this Cairo smart contract repository
+---
+
+## Creating Pull Requests
+
+### Before Creating a PR
+
+1. **Run all checks locally:**
+   ```bash
+   make lint-check  # Format and build check
+   scarb test       # Run all tests
+   ```
+
+2. **Ensure your branch is up to date:**
+   ```bash
+   git fetch origin
+   git rebase origin/main
+   ```
+
+### Commit Message Format
+
+Use conventional commits:
+- `feat:` New feature
+- `fix:` Bug fix
+- `refactor:` Code refactoring
+- `docs:` Documentation changes
+- `test:` Test additions or fixes
+- `chore:` Maintenance tasks
+
+Example: `feat: add session caching to reduce transaction costs`
+
+### PR Title and Description
+
+**Title**: Use the same format as commit messages (e.g., `feat: add multi-owner support`)
+
+**Description template**:
+```markdown
+## Summary
+Brief description of what this PR does and why.
+
+## Changes
+- List key changes
+- One bullet per logical change
+
+## Testing
+- Describe how this was tested
+- Reference specific test files if applicable
+
+## Breaking Changes
+List any breaking changes (if none, omit this section)
+```
+
+### Creating the PR
+
+```bash
+gh pr create --title "feat: your feature" --body "$(cat <<'EOF'
+## Summary
+<description>
+
+## Changes
+- <change 1>
+- <change 2>
+
+## Testing
+- <how tested>
+EOF
+)"
+```
+
+### Checklist Before Submitting
+
+- [ ] All tests pass (`scarb test`)
+- [ ] Code is formatted (`scarb fmt`)
+- [ ] Build succeeds (`scarb build`)
+- [ ] No new warnings introduced
+- [ ] Documentation updated if needed
+- [ ] Changelog updated for user-facing changes

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: review-code
+description: Review Cairo smart contract code for security and best practices
+---
+
+## Code Review Checklist
+
+### Security Checks
+
+**Access Control:**
+- [ ] Functions check caller authorization (`get_caller_address()`)
+- [ ] Owner-only functions properly restricted
+- [ ] Multi-sig requirements enforced where needed
+- [ ] No unauthorized state modifications
+
+**Signature Verification:**
+- [ ] Signatures verified before executing sensitive operations
+- [ ] Replay protection in place (nonces, unique hashes)
+- [ ] Signature malleability considered
+- [ ] All signer types handled correctly
+
+**Arithmetic:**
+- [ ] No overflow/underflow risks (Cairo handles this, but verify logic)
+- [ ] Division by zero prevented
+- [ ] Edge cases for zero values handled
+
+**Reentrancy:**
+- [ ] State updated before external calls
+- [ ] Check-effects-interactions pattern followed
+- [ ] Reentrant calls considered in design
+
+**Storage:**
+- [ ] Storage keys don't collide
+- [ ] Mappings use appropriate key types
+- [ ] Storage reads/writes are intentional
+
+### Code Quality
+
+**Formatting:**
+- [ ] 120 character line limit respected
+- [ ] Consistent naming conventions
+- [ ] Proper indentation
+- [ ] Run `scarb fmt` to verify
+
+**Structure:**
+- [ ] Functions are focused (single responsibility)
+- [ ] Complex logic broken into helper functions
+- [ ] Interfaces properly defined
+- [ ] Events emitted for state changes
+
+**Documentation:**
+- [ ] Public functions documented
+- [ ] Complex logic explained
+- [ ] Edge cases noted
+
+### Smart Contract Specifics
+
+**Upgradeability:**
+- [ ] Upgrade functions properly protected
+- [ ] State migration considered
+- [ ] No storage layout conflicts
+
+**Gas Efficiency:**
+- [ ] Avoid unnecessary storage reads/writes
+- [ ] Batch operations where possible
+- [ ] Consider calldata size
+
+**Error Handling:**
+- [ ] Descriptive error messages
+- [ ] Fail early with clear assertions
+- [ ] No silent failures
+
+### Component-Specific Reviews
+
+**For Signer Components:**
+- [ ] All signer types validated correctly
+- [ ] GUID calculation consistent
+- [ ] Signature format matches specification
+
+**For Session Components:**
+- [ ] Session expiration checked
+- [ ] Method restrictions enforced
+- [ ] Revocation works correctly
+
+**For Outside Execution:**
+- [ ] Caller authorization verified
+- [ ] Signature covers all execution parameters
+- [ ] Replay protection active
+
+### Testing Coverage
+
+- [ ] Happy path tested
+- [ ] Edge cases covered
+- [ ] Error conditions tested (`#[should_panic]`)
+- [ ] Events verified
+- [ ] All public functions have tests
+
+### Common Issues to Watch For
+
+1. **Missing access control** - Always verify caller permissions
+2. **Incorrect hash computation** - Verify hash inputs match spec
+3. **Storage collision** - Component storage must not overlap
+4. **Unchecked external calls** - Validate return values
+5. **Hardcoded values** - Use constants or configuration
+6. **Missing events** - State changes should emit events

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: update-pr
+description: Update existing pull requests based on review feedback
+---
+
+## Updating Pull Requests
+
+### Responding to Review Feedback
+
+1. **Read all comments** before making changes
+2. **Address each comment** - either fix or explain why not
+3. **Re-run checks** after making changes
+
+### Making Changes
+
+**For small fixes** (typos, minor adjustments):
+```bash
+# Make changes, then amend the last commit
+git add -A
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+**For significant changes** (new logic, multiple files):
+```bash
+# Create a new commit with descriptive message
+git add -A
+git commit -m "fix: address review feedback - <specific change>"
+git push
+```
+
+### When to Amend vs New Commit
+
+**Amend when:**
+- Fixing typos or formatting
+- Small adjustments to the same logical change
+- Pre-commit hooks auto-modified files
+
+**New commit when:**
+- Adding new functionality based on feedback
+- Making substantial changes to approach
+- Changes that warrant their own description
+
+### Re-running Checks
+
+After pushing updates:
+```bash
+make lint-check  # Verify formatting and build
+scarb test       # Run all tests
+```
+
+### Responding to Comments
+
+Use GitHub's "Resolve conversation" feature after addressing each comment.
+
+For comments you disagree with:
+- Explain your reasoning clearly
+- Reference documentation or prior decisions if applicable
+- Be open to discussion
+
+### Updating PR Description
+
+If the scope changed significantly:
+```bash
+gh pr edit <PR_NUMBER> --body "$(cat <<'EOF'
+## Summary
+<updated description>
+
+## Changes
+- <updated changes>
+
+## Testing
+- <updated testing notes>
+EOF
+)"
+```
+
+### Force Push Safety
+
+Always use `--force-with-lease` instead of `--force`:
+```bash
+git push --force-with-lease
+```
+
+This prevents accidentally overwriting commits pushed by others.

--- a/.claude/skills/write-cairo/SKILL.md
+++ b/.claude/skills/write-cairo/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: write-cairo
+description: Write Cairo code following the Cairo Book and project conventions
+---
+
+## Cairo Development Guide
+
+### Reference
+
+The Cairo Book: https://www.starknet.io/cairo-book/
+
+### Project Conventions
+
+**Formatting:**
+- 120 character line limit
+- Sorted module-level items (imports, declarations)
+- Run `scarb fmt` before committing
+
+**File Structure:**
+- Interfaces in `interface.cairo` files
+- Implementations in separate files
+- Group related functionality in directories
+
+### Core Cairo Patterns
+
+**Variables and Types:**
+```cairo
+let x: felt252 = 5;           // Immutable by default
+let mut y: u256 = 10;         // Mutable with 'mut'
+let z: Option<felt252> = Option::Some(1);
+```
+
+**Functions:**
+```cairo
+fn function_name(param: Type) -> ReturnType {
+    // implementation
+}
+```
+
+**Structs and Traits:**
+```cairo
+#[derive(Drop, Serde, starknet::Store)]
+struct MyStruct {
+    field: felt252,
+}
+
+trait MyTrait<T> {
+    fn my_method(self: @T) -> felt252;
+}
+```
+
+### Starknet Contract Patterns
+
+**Component Pattern** (used extensively in this project):
+```cairo
+#[starknet::component]
+pub mod my_component {
+    #[storage]
+    struct Storage {
+        value: felt252,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        new_value: felt252,
+    }
+
+    #[embeddable_as(MyComponentImpl)]
+    impl MyComponent<
+        TContractState, +HasComponent<TContractState>
+    > of super::IMyComponent<ComponentState<TContractState>> {
+        fn get_value(self: @ComponentState<TContractState>) -> felt252 {
+            self.value.read()
+        }
+    }
+}
+```
+
+**Embedding Components:**
+```cairo
+#[starknet::contract]
+mod MyContract {
+    component!(path: my_component, storage: my_storage, event: MyEvent);
+
+    #[abi(embed_v0)]
+    impl MyComponentImpl = my_component::MyComponent<ContractState>;
+}
+```
+
+### Project-Specific Patterns
+
+**Signer Types** (see `src/signer/`):
+- `StarknetSigner` - Native Starknet signatures
+- `Secp256k1Signer` - Ethereum-compatible (EIP191)
+- `Secp256r1Signer` - WebAuthn/Passkeys
+- `Eip191Signer` - EIP-191 signatures
+- `WebauthnSigner` - Full WebAuthn support
+
+**Storage Patterns:**
+```cairo
+// Use felt252 for simple values
+value: felt252,
+
+// Use LegacyMap for mappings
+owners: LegacyMap<felt252, bool>,
+
+// Use specialized storage types from utils
+// See src/utils/array_store.cairo for array storage
+```
+
+### Error Handling
+
+```cairo
+// Use assert with error messages
+assert(condition, 'error message');
+
+// For recoverable errors, use Result/Option
+fn may_fail() -> Result<felt252, felt252> {
+    if condition {
+        Result::Ok(value)
+    } else {
+        Result::Err('error')
+    }
+}
+```
+
+### Common Imports
+
+```cairo
+use starknet::{ContractAddress, get_caller_address, get_contract_address};
+use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+use core::poseidon::poseidon_hash_span;
+```

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: write-tests
+description: Write tests using Starknet Foundry following project conventions
+---
+
+## Testing with Starknet Foundry
+
+### Running Tests
+
+```bash
+scarb test                    # Run all tests
+scarb test <test_name>        # Run specific test
+snforge test                  # Alternative command
+```
+
+### Test File Structure
+
+Tests are in `tests/` directory:
+- `tests/setup/` - Test utilities and setup helpers
+- `tests/test_*.cairo` - Test files (prefix with `test_`)
+- `tests/lib.cairo` - Module declarations
+
+### Writing Tests
+
+**Basic Test:**
+```cairo
+#[test]
+fn test_my_feature() {
+    // Arrange
+    let value = 5;
+    
+    // Act
+    let result = my_function(value);
+    
+    // Assert
+    assert(result == expected, 'unexpected result');
+}
+```
+
+**Test with Expected Failure:**
+```cairo
+#[test]
+#[should_panic(expected: 'error message')]
+fn test_should_fail() {
+    // Code that should panic
+}
+```
+
+### Test Setup Utilities
+
+This project provides setup helpers in `tests/setup/`:
+
+**Account Setup** (`account_test_setup.cairo`):
+```cairo
+use tests::setup::account_test_setup::{
+    deploy_controller_account,
+    // other helpers
+};
+```
+
+**Constants** (`constants.cairo`):
+```cairo
+use tests::setup::constants::{
+    OWNER,
+    // other test constants
+};
+```
+
+**Utilities** (`utils.cairo`):
+```cairo
+use tests::setup::utils::{
+    // helper functions
+};
+```
+
+### Starknet Foundry Features
+
+**Cheatcodes:**
+```cairo
+use snforge_std::{
+    start_cheat_caller_address,
+    stop_cheat_caller_address,
+    start_cheat_block_timestamp,
+    spy_events,
+    // etc.
+};
+
+#[test]
+fn test_with_cheatcodes() {
+    let contract_address = deploy_contract();
+    
+    // Spoof caller
+    start_cheat_caller_address(contract_address, OWNER());
+    
+    // Make call as OWNER
+    contract.do_something();
+    
+    stop_cheat_caller_address(contract_address);
+}
+```
+
+**Event Testing:**
+```cairo
+#[test]
+fn test_events() {
+    let mut spy = spy_events();
+    
+    // Trigger event
+    contract.do_something();
+    
+    // Assert event was emitted
+    spy.assert_emitted(@array![
+        (contract_address, Event::MyEvent(MyEvent { value: 42 }))
+    ]);
+}
+```
+
+### Test Organization
+
+**Group related tests:**
+```cairo
+mod test_feature_x {
+    #[test]
+    fn test_basic_case() { }
+    
+    #[test]
+    fn test_edge_case() { }
+    
+    #[test]
+    #[should_panic]
+    fn test_invalid_input() { }
+}
+```
+
+### Naming Conventions
+
+- Test files: `test_<feature>.cairo`
+- Test functions: `test_<what_is_tested>`
+- Setup functions: `setup_<what>` or `deploy_<contract>`
+
+### Common Patterns in This Project
+
+**Testing Signatures:**
+```cairo
+// See tests/test_argent_account_signatures.cairo
+// for signature verification test patterns
+```
+
+**Testing Multisig:**
+```cairo
+// See tests/test_multisig_*.cairo
+// for multisig-related test patterns
+```
+
+**Testing Components:**
+```cairo
+// See tests/test_comp_*.cairo
+// for component testing patterns
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Skills
+
+This repository includes specialized skills in `.claude/skills/`:
+
+- **create-pr** - Guidelines for creating well-formed pull requests
+- **update-pr** - How to update PRs based on review feedback
+- **write-cairo** - Cairo coding patterns and project conventions
+- **write-tests** - Testing with Starknet Foundry
+- **review-code** - Security checklist for Cairo smart contracts
+
 ## Commands
 
 ### Testing

--- a/bin/lint
+++ b/bin/lint
@@ -137,9 +137,9 @@ run_prettier_lint() {
     else
         # Lint all documentation files
         if [ "$CHECK_ONLY" = true ]; then
-            prettier --check "**/*.{md,yml,yaml,json}" --ignore-path .prettierignore 2>/dev/null || true
+            prettier --check "**/*.{md,yml,yaml,json}" --ignore-path .prettierignore
         else
-            prettier --write "**/*.{md,yml,yaml,json}" --ignore-path .prettierignore 2>/dev/null || true
+            prettier --write "**/*.{md,yml,yaml,json}" --ignore-path .prettierignore
         fi
     fi
 }

--- a/docs/controller_account.md
+++ b/docs/controller_account.md
@@ -72,4 +72,4 @@ See [Sessions](./sessions.md)
 
 ## Upgrades
 
-See [Upgrades](./argen_account_upgrades.md)
+See [Upgrades](./controller_account_upgrades.md)

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -129,7 +129,3 @@ struct Session {
   }
 }
 ```
-
-### Examples
-
-There are some examples in typescript about how to use this feature [here](../lib/session/) and [here](../tests-integration/sessionAccount.test.ts)


### PR DESCRIPTION
## Summary

Adds Claude skills for AI-assisted development, fixes CI/hooks alignment, and cleans up documentation.

## Changes

- **Add `.claude/skills/`** with 5 specialized skills:
  - `create-pr` - Guidelines for creating well-formed PRs
  - `update-pr` - How to update PRs based on feedback  
  - `write-cairo` - Cairo coding patterns and conventions (references Cairo Book)
  - `write-tests` - Testing with Starknet Foundry
  - `review-code` - Security checklist for Cairo contracts

- **Fix `bin/lint`** to properly propagate prettier errors (was silently swallowed with `|| true`, causing CI to fail but local lint to pass)

- **Update `CLAUDE.md`** with skills reference section

- **Fix documentation**:
  - `docs/controller_account.md`: Fix typo (`argen_account_upgrades.md` → `controller_account_upgrades.md`)
  - `docs/sessions.md`: Remove dead references to non-existent `lib/session/` and `tests-integration/` directories

## Testing

- Verified skill files follow Claude conventions (YAML frontmatter with `name` and `description`)
- Checked that `bin/lint` now properly exits with error code on prettier failures